### PR TITLE
refactor: 파일 저장소를 FileStorage 인터페이스로 추상화

### DIFF
--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/controller/FileController.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/controller/FileController.kt
@@ -7,7 +7,7 @@ import org.core.scheduleflow.domain.file.service.FileService
 import org.core.scheduleflow.global.dto.PageResponse
 import org.core.scheduleflow.global.exception.CustomException
 import org.core.scheduleflow.global.exception.ErrorCode
-import org.springframework.core.io.UrlResource
+import org.springframework.core.io.Resource
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -64,7 +64,7 @@ class FileController(
     }
 
     @GetMapping("/download/{fileId}")
-    fun downloadFile(@PathVariable fileId: Long): ResponseEntity<UrlResource>{
+    fun downloadFile(@PathVariable fileId: Long): ResponseEntity<Resource>{
         return fileService.downloadFile(fileId)
     }
 

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/service/FileService.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/service/FileService.kt
@@ -1,18 +1,16 @@
 package org.core.scheduleflow.domain.file.service
 
-import jakarta.annotation.PostConstruct
 import org.core.scheduleflow.domain.file.constant.FileCategory
 import org.core.scheduleflow.domain.file.dto.FileListResponse
 import org.core.scheduleflow.domain.file.dto.FileResponse
 import org.core.scheduleflow.domain.file.entity.FileEntity
 import org.core.scheduleflow.domain.file.repository.FileRepository
+import org.core.scheduleflow.domain.file.storage.FileStorage
 import org.core.scheduleflow.domain.project.repository.ProjectRepository
 import org.core.scheduleflow.domain.user.repository.UserRepository
 import org.core.scheduleflow.global.exception.CustomException
 import org.core.scheduleflow.global.exception.ErrorCode
-import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.core.io.UrlResource
+import org.springframework.core.io.Resource
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -22,12 +20,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.util.UriUtils
-import java.io.IOException
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 
-import java.nio.file.Paths
-import java.nio.file.StandardCopyOption
 import java.util.UUID
 import kotlin.String
 
@@ -35,43 +29,22 @@ import kotlin.String
 @Service
 class FileService(
     private val fileRepository: FileRepository,
-    @Value("\${storage.path}") private val uploadPath: String,
     private val projectRepository: ProjectRepository,
     private val userRepository: UserRepository,
-
+    private val fileStorage: FileStorage,
 ) {
-    private val logger = LoggerFactory.getLogger(this.javaClass)
-
-    private val rootLocation = Paths.get(uploadPath).toAbsolutePath().normalize()
-
-    @PostConstruct
-    fun init() {
-        try {
-            Files.createDirectories(rootLocation)
-        } catch (e: IOException) {
-            throw RuntimeException("루트 폴더를 생성할 수 없습니다.", e)
-        }
-    }
-
     @Transactional(readOnly = true)
     fun findFiles(pageable: Pageable, keyword: String?): Page<FileListResponse> {
-
         if(!keyword.isNullOrBlank()) {
             return fileRepository.findByFileName(pageable, keyword)
         }
-
         return fileRepository.findFiles(pageable)
     }
 
     @Transactional(readOnly = true)
     fun findByProjectId(projectId: Long): List<FileResponse> {
-
         val files = fileRepository.findByProjectId(projectId)
-
-        if (files.isEmpty()) {
-            return emptyList()
-        }
-
+        if (files.isEmpty()) return emptyList()
         return files.map { partner ->
             partner.let { FileResponse.fromEntity(it) }
         }
@@ -84,85 +57,42 @@ class FileService(
         category: FileCategory,
         userId: Long
     ): FileResponse {
-
-        /* 카테고리별 디렉토리 조회하여 없으면 생성 */
-        val fileLocation = rootLocation.resolve(category.name).normalize()
-        if (!Files.exists(fileLocation)) {
-            Files.createDirectories(fileLocation)
-        }
-
         val originalFileName = file.originalFilename ?: "unknown"
         val extension = originalFileName.substringAfterLast(".", "")
         val storedName = "${UUID.randomUUID()}.$extension"
-        val destinationFile = fileLocation.resolve(storedName)
-        
-        /* 물리저장 */
-        file.inputStream.use { inputStream ->
-            Files.copy(inputStream, destinationFile, StandardCopyOption.REPLACE_EXISTING)
-        }
-        
-        /* 메타 데이터 저장 */
+        val key = "${category.name}/$storedName"
+        fileStorage.store(key, file)
         val uploadFile = fileRepository.save(FileEntity(
             project = projectRepository.findByIdOrNull(projectId) ?: throw CustomException(ErrorCode.NOT_FOUND_PROJECT),
             user = userRepository.findByIdOrNull(userId) ?: throw CustomException(ErrorCode.NOT_FOUND_USER),
             category = category,
             storedFileName = storedName,
             originalFileName = originalFileName,
-            filePath = destinationFile.toString(),
+            filePath = key,
             fileSize = file.size,
-            contentType = file.contentType.toString() ?: "application/octet-stream",
+            contentType = file.contentType.toString(),
         ))
-        
         return FileResponse.fromEntity(uploadFile)
     }
 
     @Transactional
-    fun downloadFile(fileId: Long): ResponseEntity<UrlResource> {
-        val downloadFile = fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
-
-        val filePath = Paths.get(downloadFile.filePath)
-        val resource = UrlResource(filePath.toUri())
-
+    fun downloadFile(fileId: Long): ResponseEntity<Resource> {
+        val file = fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
+        val resource = fileStorage.loadAsResource(file.filePath)
         if(!resource.exists() || !resource.isReadable) throw CustomException(ErrorCode.NOT_FOUND_FILE)
-
-        val encodedFileName = UriUtils.encode(downloadFile.originalFileName, StandardCharsets.UTF_8)
-
+        val encodedFileName = UriUtils.encode(file.originalFileName, StandardCharsets.UTF_8)
         val contentDisposition = "attachment; filename=\"$encodedFileName\""
-
         return ResponseEntity.ok()
-            .header(HttpHeaders.CONTENT_TYPE, downloadFile.contentType)
+            .header(HttpHeaders.CONTENT_TYPE, file.contentType)
             .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
-            .contentLength(downloadFile.fileSize)
+            .contentLength(file.fileSize)
             .body(resource)
-
     }
 
     @Transactional
     fun deleteFile(fileId: Long) {
-        val deleteFile = fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
-
-        val filePath = Paths.get(deleteFile.filePath)
-
-        try {
-            val isDeleted = Files.deleteIfExists(filePath)
-
-            if(isDeleted) {
-                // 로그용
-                logger.info("파일 삭제 완료 : {}", deleteFile.filePath)
-            } else {
-                // 로그용
-                logger.warn("파일이 존재하지 않아 삭제되지 않았습니다 : {}", deleteFile.filePath)
-            }
-
-        } catch (e: IOException) {
-
-            logger.error("파일 삭제 중 I/O 오류 발생: {}", deleteFile.filePath, e)
-            throw CustomException(ErrorCode.FAIL_DELETE_FILE)
-
-        }
-
-        fileRepository.delete(deleteFile)
+        val file = fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
+        fileStorage.delete(file.filePath)
+        fileRepository.delete(file)
     }
-
-
 }

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/FileStorage.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/FileStorage.kt
@@ -1,0 +1,10 @@
+package org.core.scheduleflow.domain.file.storage
+
+import org.springframework.core.io.Resource
+import org.springframework.web.multipart.MultipartFile
+
+interface FileStorage {
+    fun store(key: String, file: MultipartFile)
+    fun loadAsResource(key: String): Resource
+    fun delete(key: String)
+}

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/LocalFileStorage.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/LocalFileStorage.kt
@@ -1,0 +1,61 @@
+package org.core.scheduleflow.domain.file.storage
+
+import jakarta.annotation.PostConstruct
+import org.core.scheduleflow.global.exception.CustomException
+import org.core.scheduleflow.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.Resource
+import org.springframework.core.io.UrlResource
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+@Component
+class LocalFileStorage(
+    @Value("\${storage.path}")
+    private val uploadPath: String,
+    )
+: FileStorage{
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+    private val rootLocation = Path.of(uploadPath).toAbsolutePath().normalize()
+
+    @PostConstruct
+    fun init() {
+        try {
+            Files.createDirectories(rootLocation)
+        } catch (e: IOException) {
+            throw RuntimeException("루트 폴더를 생성할 수 없습니다.", e)
+        }
+    }
+
+    override fun store(key: String, file: MultipartFile) {
+        val target = rootLocation.resolve(key).normalize()
+        Files.createDirectories(target.parent)
+        file.inputStream.use { inputStream ->
+            Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    override fun loadAsResource(key: String): Resource =
+        UrlResource(rootLocation.resolve(key).normalize().toUri())
+
+
+    override fun delete(key: String) {
+        val target = rootLocation.resolve(key).normalize()
+        try {
+            val isDeleted = Files.deleteIfExists(target)
+            if(isDeleted) {
+                logger.info("파일 삭제 완료 : {}", key)
+            } else {
+                logger.warn("파일이 존재하지 않아 삭제되지 않았습니다 : {}", key)
+            }
+        } catch (e: IOException) {
+            logger.error("파일 삭제 중 I/O 오류 발생: {}", key, e)
+            throw CustomException(ErrorCode.FAIL_DELETE_FILE)
+        }
+    }
+}

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/LocalFileStorage.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/LocalFileStorage.kt
@@ -33,19 +33,19 @@ class LocalFileStorage(
     }
 
     override fun store(key: String, file: MultipartFile) {
-        val target = rootLocation.resolve(key).normalize()
-        Files.createDirectories(target.parent)
+        val target = resolvePath(key)
+        target.parent?.let { Files.createDirectories(target.parent) }
         file.inputStream.use { inputStream ->
             Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING)
         }
     }
 
     override fun loadAsResource(key: String): Resource =
-        UrlResource(rootLocation.resolve(key).normalize().toUri())
+        UrlResource(resolvePath(key).toUri())
 
 
     override fun delete(key: String) {
-        val target = rootLocation.resolve(key).normalize()
+        val target = resolvePath(key)
         try {
             val isDeleted = Files.deleteIfExists(target)
             if(isDeleted) {
@@ -57,5 +57,11 @@ class LocalFileStorage(
             logger.error("파일 삭제 중 I/O 오류 발생: {}", key, e)
             throw CustomException(ErrorCode.FAIL_DELETE_FILE)
         }
+    }
+
+    private fun resolvePath(key: String): Path {
+        val target = rootLocation.resolve(key).normalize()
+        require(target.startsWith(rootLocation)) { "잘못된 파일 경로입니다." }
+        return target
     }
 }

--- a/backend/src/test/kotlin/org/core/scheduleflow/domain/file/service/FileServiceTest.kt
+++ b/backend/src/test/kotlin/org/core/scheduleflow/domain/file/service/FileServiceTest.kt
@@ -7,14 +7,13 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.core.scheduleflow.domain.file.constant.FileCategory
 import org.core.scheduleflow.domain.file.dto.FileListResponse
 import org.core.scheduleflow.domain.file.entity.FileEntity
 import org.core.scheduleflow.domain.file.repository.FileRepository
+import org.core.scheduleflow.domain.file.storage.FileStorage
 import org.core.scheduleflow.domain.partner.entity.Partner
 import org.core.scheduleflow.domain.project.entity.Project
 import org.core.scheduleflow.domain.project.repository.ProjectRepository
@@ -22,17 +21,13 @@ import org.core.scheduleflow.domain.user.entity.User
 import org.core.scheduleflow.domain.user.repository.UserRepository
 import org.core.scheduleflow.global.exception.CustomException
 import org.core.scheduleflow.global.exception.ErrorCode
-import org.springframework.core.io.UrlResource
+import org.springframework.core.io.Resource
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.web.multipart.MultipartFile
-import java.io.InputStream
-import java.nio.file.CopyOption
-import java.nio.file.Files
-import java.nio.file.Path
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -43,8 +38,8 @@ class FileServiceTest : BehaviorSpec({
     val fileRepository = mockk<FileRepository>()
     val projectRepository = mockk<ProjectRepository>()
     val userRepository = mockk<UserRepository>()
-    val uploadPath = "/tmp/test-upload"
-    val fileService = FileService(fileRepository, uploadPath, projectRepository, userRepository)
+    val fileStorage = mockk<FileStorage>()
+    val fileService = FileService(fileRepository, projectRepository, userRepository, fileStorage)
 
     fun createPartner(id: Long = 1L): Partner {
         return Partner(id = id, companyName = "발주처", mainPhone = "02-1234-5678")
@@ -108,10 +103,7 @@ class FileServiceTest : BehaviorSpec({
         every { projectRepository.findByIdOrNull(1L) } returns project
         every { userRepository.findByIdOrNull(1L) } returns user
 
-        mockkStatic(Files::class)
-        every { Files.exists(any()) } returns true
-        every { Files.createDirectories(any<Path>()) } returns mockk()
-        every { Files.copy(any<InputStream>(), any<Path>(), any<CopyOption>()) } returns 13L
+        every { fileStorage.store(any(), mockFile) } returns Unit
 
         every { fileRepository.save(any()) } answers {
             val entity = firstArg<FileEntity>()
@@ -134,6 +126,7 @@ class FileServiceTest : BehaviorSpec({
             Then("파일 정보가 반환된다") {
                 result.originalFileName shouldBe "test_document.txt"
                 result.category shouldBe FileCategory.QUOTATION
+                verify(exactly = 1) { fileStorage.store(any(), mockFile) }
                 verify(exactly = 1) { fileRepository.save(any()) }
                 verify(exactly = 1) { projectRepository.findByIdOrNull(1L) }
                 verify(exactly = 1) { userRepository.findByIdOrNull(1L) }
@@ -148,8 +141,7 @@ class FileServiceTest : BehaviorSpec({
 
         every { fileRepository.findByIdOrNull(1L) } returns fileEntity
 
-        mockkStatic(Files::class)
-        every { Files.deleteIfExists(any()) } returns true
+        every { fileStorage.delete(fileEntity.filePath) } returns Unit
         every { fileRepository.delete(fileEntity) } returns Unit
 
         When("파일을 삭제하면") {
@@ -157,7 +149,7 @@ class FileServiceTest : BehaviorSpec({
 
             Then("파일이 삭제된다") {
                 verify(exactly = 1) { fileRepository.findByIdOrNull(1L) }
-                verify(exactly = 1) { Files.deleteIfExists(any()) }
+                verify(exactly = 1) { fileStorage.delete(fileEntity.filePath) }
                 verify(exactly = 1) { fileRepository.delete(fileEntity) }
             }
         }
@@ -170,9 +162,10 @@ class FileServiceTest : BehaviorSpec({
 
         every { fileRepository.findByIdOrNull(1L) } returns fileEntity
 
-        mockkConstructor(UrlResource::class)
-        every { anyConstructed<UrlResource>().exists() } returns true
-        every { anyConstructed<UrlResource>().isReadable } returns true
+        val resource = mockk<Resource>()
+        every { fileStorage.loadAsResource(fileEntity.filePath) } returns resource
+        every { resource.exists() } returns true
+        every { resource.isReadable } returns true
 
         When("파일을 다운로드하면") {
             val responseEntity = fileService.downloadFile(1L)
@@ -180,6 +173,7 @@ class FileServiceTest : BehaviorSpec({
             Then("파일 리소스가 반환된다") {
                 responseEntity.statusCode shouldBe HttpStatus.OK
                 responseEntity.headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)!! shouldContain "download.txt"
+                verify(exactly = 1) { fileStorage.loadAsResource(fileEntity.filePath) }
                 verify(exactly = 1) { fileRepository.findByIdOrNull(1L) }
             }
         }


### PR DESCRIPTION
## 개요
파일 저장 로직을 `FileStorage` 인터페이스로 추상화했습니다. 기존에는 `FileService`가 로컬 파일시스템 I/O(`Files`, `UrlResource`)에 직접 의존하고 있었는데, 저장소 구현을 인터페이스 뒤로 분리했습니다.

## 변경 사항
- **`FileStorage` 인터페이스 신설** — `store` / `loadAsResource` / `delete` 3개 메서드로 저장소 계약 정의
- **`LocalFileStorage` 구현체 추가** — 기존 로컬 파일시스템 I/O 로직을 이관 (경로 정규화, 디렉토리 생성, 삭제 시 로깅/예외 처리 포함)
- **`FileService` 슬림화** — 저장소 세부 구현 의존 제거, `FileStorage`에 위임 (104줄 → 대폭 축소)
- **테스트 수정** — `FileServiceTest`가 `FileStorage`를 mocking하도록 변경 (파일 I/O 정적 mock 불필요)

## 왜
- 저장소 구현 교체 지점을 인터페이스 하나로 좁혀둠 → 추후 **S3 등 클라우드 스토리지로 전환** 시 `FileService` 수정 없이 구현체만 추가하면 됨 (AWS 개편 로드맵 대비)
- `FileService`가 비즈니스 로직에만 집중하게 되어 테스트가 파일시스템에서 분리됨

## 테스트
- `FileServiceTest` — `FileStorage` mock 기반으로 통과

## 관련 이슈
- #92 Close

