### PR TITLE
feat: 파일 저장소 S3 지원 추가 및 프로파일별 스토리지 분리

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-security-test")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
     testRuntimeOnly("com.h2database:h2")
+
+    // AWS SDK v2 - S3
+    implementation(platform("software.amazon.awssdk:bom:2.46.20"))
+    implementation("software.amazon.awssdk:s3")
 }
 
 kotlin {

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/LocalFileStorage.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/LocalFileStorage.kt
@@ -5,6 +5,7 @@ import org.core.scheduleflow.global.exception.CustomException
 import org.core.scheduleflow.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.core.io.Resource
 import org.springframework.core.io.UrlResource
 import org.springframework.stereotype.Component
@@ -15,6 +16,7 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 
 @Component
+@ConditionalOnProperty(name = ["storage.type"], havingValue = "local", matchIfMissing = true)
 class LocalFileStorage(
     @Value("\${storage.path}")
     private val uploadPath: String,

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/S3FileStorage.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/S3FileStorage.kt
@@ -4,7 +4,7 @@ import org.core.scheduleflow.global.exception.CustomException
 import org.core.scheduleflow.global.exception.ErrorCode
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.core.io.ByteArrayResource
+import org.springframework.core.io.InputStreamResource
 import org.springframework.core.io.Resource
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
@@ -31,15 +31,15 @@ class S3FileStorage(
         s3Client.putObject(request, RequestBody.fromInputStream(file.inputStream, file.size))
     }
 
-    // 다운로드: S3에서 GET 해서 Resource로 감싸 반환
+    // 다운로드: S3에서 GET 스트림을 열어 Resource로 감싸 반환 (메모리에 전체 적재 안 함)
     override fun loadAsResource(key: String): Resource {
         val request = GetObjectRequest.builder()
             .bucket(bucket)
             .key(key)
             .build()
         return try {
-            val bytes = s3Client.getObjectAsBytes(request).asByteArray()  // 통째로 메모리에
-            ByteArrayResource(bytes)   // Spring이 이해하는 Resource로 포장
+            val stream = s3Client.getObject(request)  // ResponseInputStream, 스트리밍
+            InputStreamResource(stream)               // 스트림을 그대로 감쌈 (힙에 안 쌓임)
         } catch (e: NoSuchKeyException) {
             throw CustomException(ErrorCode.NOT_FOUND_FILE)  // 없는 키 → 404로 변환
         }

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/S3FileStorage.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/storage/S3FileStorage.kt
@@ -1,0 +1,56 @@
+package org.core.scheduleflow.domain.file.storage
+
+import org.core.scheduleflow.global.exception.CustomException
+import org.core.scheduleflow.global.exception.ErrorCode
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.core.io.Resource
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+@Component
+@ConditionalOnProperty(name = ["storage.type"], havingValue = "s3")
+class S3FileStorage(
+    private val s3Client: S3Client,
+    @Value("\${aws.s3.bucket}") private val bucket: String,
+): FileStorage {
+    override fun store(key: String, file: MultipartFile) {
+        val request = PutObjectRequest.builder()
+            .bucket(bucket)            // 어느 버킷에
+            .key(key)                  // 어떤 경로(키)로  예: QUOTATION/uuid.txt
+            .contentType(file.contentType)  // 파일 타입 메타데이터
+            .build()
+        // 두 번째 인자 = 실제 파일 내용(본문). 스트림과 크기를 넘김
+        s3Client.putObject(request, RequestBody.fromInputStream(file.inputStream, file.size))
+    }
+
+    // 다운로드: S3에서 GET 해서 Resource로 감싸 반환
+    override fun loadAsResource(key: String): Resource {
+        val request = GetObjectRequest.builder()
+            .bucket(bucket)
+            .key(key)
+            .build()
+        return try {
+            val bytes = s3Client.getObjectAsBytes(request).asByteArray()  // 통째로 메모리에
+            ByteArrayResource(bytes)   // Spring이 이해하는 Resource로 포장
+        } catch (e: NoSuchKeyException) {
+            throw CustomException(ErrorCode.NOT_FOUND_FILE)  // 없는 키 → 404로 변환
+        }
+    }
+
+    // 삭제: S3 객체 DELETE
+    override fun delete(key: String) {
+        val request = DeleteObjectRequest.builder()
+            .bucket(bucket)
+            .key(key)
+            .build()
+        s3Client.deleteObject(request)   // 없는 키여도 에러 안 남(멱등)
+    }
+}

--- a/backend/src/main/kotlin/org/core/scheduleflow/global/config/S3Config.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/global/config/S3Config.kt
@@ -1,0 +1,19 @@
+package org.core.scheduleflow.global.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+
+@Configuration
+class S3Config(
+    @Value("\${aws.region}") private val region: String,
+) {
+    @Bean
+    fun s3Client(): S3Client =
+        S3Client.builder()
+            .region(Region.of(region))
+            .build()
+    // DefaultCredentialsProvider가 aws cli 설정(~/.aws/credentials) 자동으로 자격증명을 탐색.
+}

--- a/backend/src/main/kotlin/org/core/scheduleflow/global/config/S3Config.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/global/config/S3Config.kt
@@ -1,12 +1,14 @@
 package org.core.scheduleflow.global.config
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 
 @Configuration
+@ConditionalOnProperty(name = ["storage.type"], havingValue = "s3")
 class S3Config(
     @Value("\${aws.region}") private val region: String,
 ) {

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,3 @@
+storage:
+  type: local
+  path: ./uploads

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,7 @@
+storage:
+  type: s3
+
+aws:
+  region: ap-northeast-2
+  s3:
+    bucket: scheduleflow-files-606531136262

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,9 @@ server:
     context-path: /api
 
 spring:
+  profiles:
+    active: local
+
   datasource:
     url: jdbc:mysql://localhost:3306/scheduleflow?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${MYSQL_USER}
@@ -30,9 +33,6 @@ spring:
 jwt:
   secret-key: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION}
-
-storage:
-  path: C:\ScheduleFlow
 
 springdoc:
   api-docs:


### PR DESCRIPTION
파일 저장소에 S3 지원을 추가하고, 프로파일로 로컬 디스크 ↔ S3를 전환한다. 실회사 데이터 내구성을 위해 파일은 S3에 저장한다(컴퓨트는 EC2 1대지만 파일은 S3).

## 관련 이슈
- Closes #93 — S3FileStorage 구현 및 프로파일 분기

## 변경 사항
### 1. S3 저장소 구현
- AWS SDK v2(`software.amazon.awssdk:s3`) 의존성 추가 (BOM으로 버전 관리)
- `S3FileStorage` 구현 (`store` / `loadAsResource` / `delete`)
- `S3Client` 빈 구성 — `DefaultCredentialsProvider`로 자격증명 자동 탐색(코드/이미지에 키 없음). 로컬은 `~/.aws`, 클라우드는 EC2 Instance Profile 사용 예정

### 2. 저장소 전환 (프로파일)
- `storage.type` 기반 `@ConditionalOnProperty`로 Local ↔ S3 빈 선택
- 프로파일 분리: `local`=로컬 디스크, `prod`=S3
- base `application.yml`에서 환경별 storage 설정을 프로파일 파일로 분리

### 3. 다운로드 스트리밍
- `getObjectAsBytes`(전체 메모리 적재) → `getObject` 스트림 + `InputStreamResource`
- 대용량(최대 1GB) 파일 다운로드 시 힙 적재 방지

## 검증
- `./gradlew :backend:compileKotlin` → BUILD SUCCESSFUL
- 실 S3 버킷 대상 업로드→다운로드(내용 일치)→삭제 왕복 수동 검증 완료(검증용 테스트는 커밋 제외)

## 범위 밖 (후속 별도 처리)
- 설정 env화(`S3_BUCKET`, `AWS_REGION`) → SSM Parameter Store 주입 (#91, 인프라/Terraform 단계)
- (선택) 다운로드 presigned URL 발급 방식 — 백엔드 부하 절감
