### PR TITLE
feat: AWS 인프라 기반 구축 (Terraform — VPC/RDS/EC2/IAM)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,10 @@ frontend/build/
 frontend/.pnp
 frontend/.pnp.js
 frontend/coverage/
+
+### Terraform ###
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,0 +1,67 @@
+# ────────────────────────────────────────────────
+# ② AMI 자동 선택 — 최신 Amazon Linux 2023 (ARM64)
+#   data 소스로 "최신 이미지"를 매번 찾아옴 → ID 하드코딩 안 함.
+#   t4g/t3 계열에 맞춰 arm64 선택 (t4g=ARM, 저렴).
+# ────────────────────────────────────────────────
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]   # Amazon 공식 이미지만
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-arm64"]   # Amazon Linux 2023, ARM64
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# ────────────────────────────────────────────────
+# ③ user-data — 부팅 시 1회 실행되는 초기화 스크립트
+#   docker/compose 설치까지만. (앱 배포는 나중에 CI/CD 또는 수동)
+#   heredoc(<<-EOF)으로 여러 줄 셸 스크립트를 그대로 넣음.
+# ────────────────────────────────────────────────
+locals {
+  user_data = <<-EOF
+    #!/bin/bash
+    set -eux
+    # 패키지 최신화 + docker 설치
+    dnf update -y
+    dnf install -y docker
+    systemctl enable --now docker
+    usermod -aG docker ec2-user            # ec2-user가 sudo 없이 docker 쓰게
+    # docker compose 플러그인 설치
+    mkdir -p /usr/local/lib/docker/cli-plugins
+    curl -sSL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-aarch64 \
+      -o /usr/local/lib/docker/cli-plugins/docker-compose
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+  EOF
+}
+
+# ────────────────────────────────────────────────
+# ④ EC2 인스턴스 — 위 ①②③을 조립
+# ────────────────────────────────────────────────
+resource "aws_instance" "app" {
+  ami           = data.aws_ami.al2023.id       # ②에서 찾은 최신 이미지
+  instance_type = "t4g.micro"                  # ARM
+
+  subnet_id                   = aws_subnet.public_a.id          # public subnet
+  vpc_security_group_ids      = [aws_security_group.web.id]     # 80/443만 열린 web SG
+  associate_public_ip_address = true                           # 인터넷에서 접근할 퍼블릭 IP
+
+  iam_instance_profile = aws_iam_instance_profile.ec2.name      # ① 신분증 장착 (SSM+S3)
+  user_data            = local.user_data                       # ③ 부팅 스크립트
+
+  # key_name 없음! → SSH 키 안 씀. SSM Session Manager로 접속.
+
+  root_block_device {
+    volume_size = 30      # GB. 프리티어 30GB 한도
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  tags = {
+    Name = "scheduleflow-app"
+  }
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -33,9 +33,34 @@ resource "aws_iam_role_policy_attachment" "ssm" {
 }
 
 
+# S3 접근 — 특정 버킷만 허용 (최소권한 원칙)
+#   AmazonS3FullAccess(모든 버킷)를 쓰지 않고, 앱 버킷 하나 + 필요한 액션만 허용.
+#   EC2가 탈취돼도 피해 범위가 이 버킷으로 한정됨.
+resource "aws_iam_policy" "s3_access" {
+  name        = "scheduleflow-s3-access"
+  description = "Allow EC2 to access the app's S3 bucket only"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+      ]
+      Resource = [
+        "arn:aws:s3:::${var.s3_bucket}",      # 버킷 자체 (ListBucket용)
+        "arn:aws:s3:::${var.s3_bucket}/*",    # 버킷 안 객체 (Get/Put/Delete용)
+      ]
+    }]
+  })
+}
+
 resource "aws_iam_role_policy_attachment" "s3" {
   role       = aws_iam_role.ec2.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  policy_arn = aws_iam_policy.s3_access.arn
 }
 
 resource "aws_iam_instance_profile" "ec2" {

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,44 @@
+# ────────────────────────────────────────────────
+# IAM Role — EC2가 달고 다닐 "신분증"
+# ────────────────────────────────────────────────
+
+# Trust policy: "누가 이 Role을 쓸 수 있나" → EC2 서비스만
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]   # "이 Role을 위임받는다"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]   # EC2 서비스가 주체
+    }
+  }
+}
+
+resource "aws_iam_role" "ec2" {
+  name               = "scheduleflow-ec2-role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json  # 위 trust policy 연결
+
+  tags = {
+    Name = "scheduleflow-ec2-role"
+  }
+}
+
+# ────────────────────────────────────────────────
+# Permission: SSM Session Manager 접속 권한
+#   AWS가 미리 만들어둔 관리형 정책(AmazonSSMManagedInstanceCore)을 붙임.
+#   이게 있어야 SSH 없이 `aws ssm start-session`으로 서버 진입 가능.
+# ────────────────────────────────────────────────
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+
+resource "aws_iam_role_policy_attachment" "s3" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_instance_profile" "ec2" {
+  name = "scheduleflow-ec2-profile"
+  role = aws_iam_role.ec2.name
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,11 @@
+output "ec2_public_ip" {
+  value = aws_instance.app.public_ip
+}
+
+output "ec2_instance_id" {
+  value = aws_instance.app.id
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.main.address
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+    required_version = ">= 1.9"
+
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "~> 5.0"
+        }
+    }
+}
+
+# 실제 AWS 접속 설정
+provider "aws" {
+  region = "ap-northeast-2"
+  # 자격증명은 이미 `aws configure`로 설정된 ~/.aws/credentials 를 자동으로 읽어감.
+}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,49 @@
+# ────────────────────────────────────────────────
+# DB Subnet Group — RDS를 어느 서브넷들에 둘지 지정
+#   아까 만든 private subnet 2개(다른 AZ)를 묶음.
+#   RDS는 single-AZ여도 2개 AZ의 서브넷을 요구(장애 대비 후보지).
+# ────────────────────────────────────────────────
+resource "aws_db_subnet_group" "main" {
+  name       = "scheduleflow-db-subnet-group"
+  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_b.id]
+
+  tags = {
+    Name = "scheduleflow-db-subnet-group"
+  }
+}
+
+# ────────────────────────────────────────────────
+# RDS MySQL 인스턴스
+# ────────────────────────────────────────────────
+resource "aws_db_instance" "main" {
+  identifier     = "scheduleflow-db"     # AWS 상의 RDS 식별자
+  engine         = "mysql"
+  engine_version = "8.0"
+  instance_class = "db.t4g.micro"        # 프리티어(12개월 750h 무료), ARM 기반
+
+  allocated_storage = 20                 # GB. 프리티어 한도 20GB
+  storage_type      = "gp3"              # 최신 범용 SSD
+  storage_encrypted = true               # 저장 데이터 암호화 (무료, 켜는 게 표준)
+
+  db_name  = var.db_name                 # variables.tf → tfvars 에서 옴
+  username = var.db_username
+  password = var.db_password             # tfvars의 비밀값
+
+  # 네트워크: private subnet에 두고, db SG만 붙임 → 인터넷 차단, EC2만 접근
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  publicly_accessible    = false         # 퍼블릭 IP 안 줌 (DB는 절대 인터넷 노출 X)
+  multi_az               = false         # 10명 규모 → single-AZ (비용 절감, 의도적 right-sizing)
+
+  # 백업
+  backup_retention_period = 7            # 7일치 자동백업 보관 → PITR(특정시점복구) 가능
+  backup_window           = "17:00-18:00" # UTC. 한국 새벽 2~3시 (트래픽 적을 때)
+
+  # 운영 편의
+  skip_final_snapshot = true             # destroy 시 마지막 스냅샷 생략(학습용). 실운영은 false 권장
+  apply_immediately   = true             # 변경을 유지보수창 기다리지 말고 즉시 적용
+
+  tags = {
+    Name = "scheduleflow-db"
+  }
+}

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -50,13 +50,9 @@ resource "aws_security_group" "db" {
     security_groups = [aws_security_group.web.id]
   }
 
-  egress {
-    description = "Allow all outbound"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"            # -1 = 모든 프로토콜
-    cidr_blocks = ["0.0.0.0/0"]   # 나가는 건 다 허용 (패키지 설치, ECR pull 등)
-  }
+  # egress 규칙 없음 = 아웃바운드 전면 차단.
+  #   RDS는 외부로 먼저 연결을 걸 일이 없음. inbound 응답은 stateful이라 egress 없이도 나감.
+  #   (private subnet이라 어차피 인터넷 경로도 없지만, 명시적으로 닫아 defense-in-depth)
 
   tags = {
     Name = "scheduleflow-db-sg"

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -1,0 +1,64 @@
+# ────────────────────────────────────────────────
+# EC2용 SG — 웹서버. 80/443만 개방, SSH(22)는 안 엶
+# ────────────────────────────────────────────────
+resource "aws_security_group" "web" {
+  name        = "scheduleflow-web-sg"
+  description = "EC2 web server: allow HTTP/HTTPS from anywhere"
+  vpc_id      = aws_vpc.main.id   # 이 SG가 속할 VPC
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]   # 인터넷 전체 허용
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # SSH(22) 규칙 없음 = 차단. SSM Session Manager로 접속하므로 불필요.
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"            # -1 = 모든 프로토콜
+    cidr_blocks = ["0.0.0.0/0"]   # 나가는 건 다 허용 (패키지 설치, ECR pull 등)
+  }
+
+  tags = {
+    Name = "scheduleflow-web-sg"
+  }
+}
+
+resource "aws_security_group" "db" {
+  name = "scheduleflow-sg-db"
+  description = "MySQL from web SG"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    description = "was"
+    from_port = 3306
+    to_port = 3306
+    protocol = "tcp"
+    security_groups = [aws_security_group.web.id]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"            # -1 = 모든 프로토콜
+    cidr_blocks = ["0.0.0.0/0"]   # 나가는 건 다 허용 (패키지 설치, ECR pull 등)
+  }
+
+  tags = {
+    Name = "scheduleflow-db-sg"
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,20 @@
+# 변수 "선언" 파일 — 값은 여기 없음(terraform.tfvars에 넣음).
+# 이 파일은 git에 올려도 안전(비밀값 없음).
+
+variable "db_name" {
+  description = "RDS에 만들 데이터베이스 이름"
+  type        = string
+  default     = "scheduleflow"   # default 있으면 tfvars에서 생략 가능
+}
+
+variable "db_username" {
+  description = "RDS 마스터 사용자 이름"
+  type        = string
+  default     = "admin"
+}
+
+variable "db_password" {
+  description = "RDS 마스터 비밀번호 (terraform.tfvars에만 넣기, git 금지)"
+  type        = string
+  sensitive   = true   #plan/apply 로그에 값이 '***'로 가려짐
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -18,3 +18,9 @@ variable "db_password" {
   type        = string
   sensitive   = true   #plan/apply 로그에 값이 '***'로 가려짐
 }
+
+variable "s3_bucket" {
+  description = "앱이 사용하는 S3 버킷 이름 (EC2 IAM 정책의 접근 대상)"
+  type        = string
+  default     = "scheduleflow-files-606531136262"
+}

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,69 @@
+# ────────────────────────────────────────────────
+# VPC — 내 전용 사설 네트워크 (모든 리소스의 바닥)
+# ────────────────────────────────────────────────
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"  # 이 VPC가 쓸 IP 범위 (약 6.5만 개)
+  enable_dns_hostnames = true           # RDS 등에 DNS 이름 붙게 함 (RDS 쓰려면 필요)
+  enable_dns_support   = true           # VPC 내부 DNS 해석 켜기
+
+  tags = {
+    Name = "scheduleflow-vpc"           # AWS 콘솔에서 보일 이름표
+  }
+}
+
+# ────────────────────────────────────────────────
+# Public Subnet — EC2가 들어갈 곳 (인터넷 노출)
+# ────────────────────────────────────────────────
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id   # 위 VPC 참조 → 이 안에 만들어짐
+  cidr_block              = "10.0.1.0/24"     # VPC 범위 안의 작은 조각 (256개)
+  availability_zone       = "ap-northeast-2a" # 어느 물리 데이터센터(AZ)에 둘지
+  map_public_ip_on_launch = true              # 여기 뜨는 EC2에 퍼블릭 IP 자동 부여
+
+  tags = {
+    Name = "scheduleflow-public-a"
+  }
+}
+
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = "ap-northeast-2a"
+
+  tags = {
+    Name = "scheduleflow-private-a"
+  }
+}
+
+resource "aws_subnet" "private_b" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.12.0/24"
+  availability_zone = "ap-northeast-2c"
+
+  tags = {
+    Name = "scheduleflow-private-b"
+  }
+}
+
+resource "aws_internet_gateway" "internet_gateway" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "scheduleflow-internet-gateway"
+  }
+}
+
+resource "aws_route_table" "route_table" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet_gateway.id
+  }
+}
+
+resource "aws_route_table_association" "route_table_association" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.route_table.id
+}

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -67,3 +67,27 @@ resource "aws_route_table_association" "route_table_association" {
   subnet_id      = aws_subnet.public_a.id
   route_table_id = aws_route_table.route_table.id
 }
+
+# ────────────────────────────────────────────────
+# Private 서브넷 전용 라우트 테이블
+#   route 블록 없음 = local 경로만 존재(인터넷 경로 없음).
+#   명시적으로 붙여서, 기본(main) 라우트 테이블에 나중에 IGW가 추가돼도
+#   private 서브넷(RDS)이 인터넷에 노출되지 않게 격리.
+# ────────────────────────────────────────────────
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "scheduleflow-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_b" {
+  subnet_id      = aws_subnet.private_b.id
+  route_table_id = aws_route_table.private.id
+}


### PR DESCRIPTION
## 개요
실사용 중인 사내 서비스를 Windows 온프렘 → AWS로 이전하기 위한 인프라 기반을
Terraform(IaC)으로 구축한다. 10명 규모에 맞춰 right-sizing하고, 백업·HTTPS·
시크릿 관리·키리스 접근을 실제 요구사항으로 갖춘다. (#98 Phase 2 전반)

## 구성 내역
- **VPC**: 10.0.0.0/16, public subnet ×1 + private subnet ×2(다른 AZ), IGW, 라우팅
- **Security Group**: web(80/443만 개방, SSH 미개방) / db(3306을 web SG 소스에서만 허용)
- **RDS MySQL**: t4g.micro, single-AZ, private subnet, 자동백업 7일, 저장 암호화, publicly_accessible=false
- **EC2**: t4g.micro(arm64), 최신 AL2023 AMI 자동 선택, public subnet, 루트볼륨 30GB 암호화
- **IAM Role + Instance Profile**: SSM 접속(AmazonSSMManagedInstanceCore) + S3 키리스 접근(AmazonS3FullAccess)
- **user-data**: 부팅 시 docker/compose 자동 설치

## 검증
- `terraform apply`로 전체 리소스 생성 성공
- **SSH(22번) 미개방 상태에서 `aws ssm start-session`으로 서버 진입 + docker 설치 확인**
- 검증 후 비용 절감 위해 `terraform destroy`($0). 코드로 언제든 재현 가능.

## 주요 결정
- **컴퓨트 arm64(t4g) 통일**: 계정 프리티어 만료(2024-11) 확인 → x86 대비 저렴. 맥이 arm64라 빌드도 네이티브
- **SSH 대신 SSM**: 22번 포트를 닫아 포트 스캔/키 유출 차단
- **도메인**: 무료 서브도메인(DuckDNS) 예정 → Caddy 자동 HTTPS (ALB $18/월 회피)

## 범위 밖 (후속 PR — 앱 배포 세션)
- ECR 리포 + 이미지 빌드/푸시
- SSM Parameter Store 시크릿 등록
- AWS용 docker-compose(RDS 연결) + DuckDNS/Caddy HTTPS
- 기존 MySQL → RDS 데이터 이전

## 관련
- #98 (AWS 인프라 구축) — Phase 2 잔여 + Phase 3 컷오버 남아 이슈 유지
- #93 (S3 — 키리스 접근 연계)
