### PR TITLE
fix: 공개 배포 전 보안 블로커 조치 + JWT 401 처리 (#103)

### DIFF
--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/service/FileService.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/service/FileService.kt
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -78,6 +79,14 @@ class FileService(
     @Transactional
     fun downloadFile(fileId: Long): ResponseEntity<Resource> {
         val file = fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
+
+        // 문서 카테고리(견적서·회로도·PLC 등)는 ADMIN만 다운로드할 수 있다.
+        // 현장 사진(PHOTO)만 인증된 사용자 누구나 받을 수 있다 — 업로드 권한 분기와 대칭.
+        // (미적용 시 저권한 사용자가 fileId 순회로 기밀문서를 전량 내려받는 IDOR 발생)
+        if (file.category != FileCategory.PHOTO && !hasAdminRole()) {
+            throw CustomException(ErrorCode.PERMISSION_DENIED)
+        }
+
         val resource = fileStorage.loadAsResource(file.filePath)
         if(!resource.exists() || !resource.isReadable) throw CustomException(ErrorCode.NOT_FOUND_FILE)
         val encodedFileName = UriUtils.encode(file.originalFileName, StandardCharsets.UTF_8)
@@ -88,6 +97,10 @@ class FileService(
             .contentLength(file.fileSize)
             .body(resource)
     }
+
+    private fun hasAdminRole(): Boolean =
+        SecurityContextHolder.getContext().authentication?.authorities
+            ?.any { it.authority == "ROLE_ADMIN" } ?: false
 
     @Transactional
     fun deleteFile(fileId: Long) {

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/file/service/FileService.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/file/service/FileService.kt
@@ -76,17 +76,11 @@ class FileService(
         return FileResponse.fromEntity(uploadFile)
     }
 
-    @Transactional
     fun downloadFile(fileId: Long): ResponseEntity<Resource> {
-        val file = fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
-
-        // 문서 카테고리(견적서·회로도·PLC 등)는 ADMIN만 다운로드할 수 있다.
-        // 현장 사진(PHOTO)만 인증된 사용자 누구나 받을 수 있다 — 업로드 권한 분기와 대칭.
-        // (미적용 시 저권한 사용자가 fileId 순회로 기밀문서를 전량 내려받는 IDOR 발생)
+        val file = getFileById(fileId)
         if (file.category != FileCategory.PHOTO && !hasAdminRole()) {
             throw CustomException(ErrorCode.PERMISSION_DENIED)
         }
-
         val resource = fileStorage.loadAsResource(file.filePath)
         if(!resource.exists() || !resource.isReadable) throw CustomException(ErrorCode.NOT_FOUND_FILE)
         val encodedFileName = UriUtils.encode(file.originalFileName, StandardCharsets.UTF_8)
@@ -98,13 +92,16 @@ class FileService(
             .body(resource)
     }
 
+    fun getFileById(fileId: Long): FileEntity =
+        fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
+
     private fun hasAdminRole(): Boolean =
         SecurityContextHolder.getContext().authentication?.authorities
             ?.any { it.authority == "ROLE_ADMIN" } ?: false
 
     @Transactional
     fun deleteFile(fileId: Long) {
-        val file = fileRepository.findByIdOrNull(fileId) ?: throw CustomException(ErrorCode.NOT_FOUND_FILE)
+        val file = getFileById(fileId)
         fileStorage.delete(file.filePath)
         fileRepository.delete(file)
     }

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/user/controller/AuthController.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/user/controller/AuthController.kt
@@ -6,6 +6,7 @@ import org.core.scheduleflow.domain.user.dto.UserSignUpRequest
 import org.core.scheduleflow.domain.user.service.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,6 +18,8 @@ class AuthController(
     private val authService: AuthService
 ) {
 
+    // 내부 ~10명 고정 사용자 도구. 셀프 가입은 막고 ADMIN이 계정을 발급한다.
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/sign-up")
     fun signUp(@RequestBody @Valid request: UserSignUpRequest): ResponseEntity<Long> {
         return ResponseEntity.status(HttpStatus.CREATED).body(

--- a/backend/src/main/kotlin/org/core/scheduleflow/domain/user/controller/UserController.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/domain/user/controller/UserController.kt
@@ -26,6 +26,8 @@ class UserController(
     private val service: UserService
 ) {
 
+    // 전 직원 목록(username·email·phone·role 포함)은 계정/멤버 편성용 관리자 기능. ADMIN만 조회.
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     fun getUsers(
         @RequestParam keyword: String?,

--- a/backend/src/main/kotlin/org/core/scheduleflow/global/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/global/config/SecurityConfig.kt
@@ -40,7 +40,8 @@ class SecurityConfig {
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers(
-                        "/auth/**",
+                        // 로그인만 공개. 회원가입(/auth/sign-up)은 ADMIN 전용이라 인증 대상에 남긴다.
+                        "/auth/sign-in",
                         "/swagger-ui/**",
                         "/swagger-ui.html",
                         "/v3/api-docs/**",

--- a/backend/src/main/kotlin/org/core/scheduleflow/global/security/jwt/JwtProvider.kt
+++ b/backend/src/main/kotlin/org/core/scheduleflow/global/security/jwt/JwtProvider.kt
@@ -4,8 +4,6 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
 import org.core.scheduleflow.domain.user.constant.Role
-import org.core.scheduleflow.global.exception.CustomException
-import org.core.scheduleflow.global.exception.ErrorCode
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
@@ -55,14 +53,18 @@ class JwtProvider(
     }
 
     fun validateToken(token: String): Result<Boolean> {
-        try{
+        // 검증 실패 시 예외를 던지지 않고 Result.failure로 돌려준다.
+        // 필터가 이 실패를 삼키고 인증을 세팅하지 않으면, 이후 authenticated() 단계에서
+        // JwtAuthenticationEntryPoint가 일관된 401을 반환한다(→ 프론트 로그인 리다이렉트).
+        // (예외를 던지면 필터 밖으로 새어나가 @RestControllerAdvice가 못 잡고 500성 응답이 됨)
+        return try {
             Jwts.parser()
                 .verifyWith(getSecurityKey(secretKey))
                 .build()
                 .parseSignedClaims(token)
-            return Result.success(true)
-        }catch (e: Exception){
-            throw CustomException(ErrorCode.INVALID_ACCESS_TOKEN)
+            Result.success(true)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 

--- a/backend/src/test/kotlin/org/core/scheduleflow/domain/file/service/FileServiceTest.kt
+++ b/backend/src/test/kotlin/org/core/scheduleflow/domain/file/service/FileServiceTest.kt
@@ -28,6 +28,9 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -41,6 +44,14 @@ class FileServiceTest : BehaviorSpec({
     val userRepository = mockk<UserRepository>()
     val fileStorage = mockk<FileStorage>()
     val fileService = FileService(fileRepository, projectRepository, userRepository, fileStorage)
+
+    // 다운로드 인가는 SecurityContext의 권한을 본다. 테스트에서 로그인 역할을 심어준다.
+    fun authenticateAs(role: String) {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("user", null, listOf(SimpleGrantedAuthority("ROLE_$role")))
+    }
+
+    afterTest { SecurityContextHolder.clearContext() }
 
     fun createPartner(id: Long = 1L): Partner {
         return Partner(id = id, companyName = "발주처", mainPhone = "02-1234-5678")
@@ -198,10 +209,10 @@ class FileServiceTest : BehaviorSpec({
         }
     }
 
-    Given("파일 다운로드 요청이 주어지고") {
+    Given("ADMIN이 문서 파일 다운로드를 요청하고") {
         val project = createProject()
         val user = createUser()
-        val fileEntity = createFileEntity(1L, project, user, originalFileName = "download.txt")
+        val fileEntity = createFileEntity(1L, project, user, originalFileName = "download.txt", category = FileCategory.QUOTATION)
 
         every { fileRepository.findByIdOrNull(1L) } returns fileEntity
 
@@ -211,6 +222,7 @@ class FileServiceTest : BehaviorSpec({
         every { resource.isReadable } returns true
 
         When("파일을 다운로드하면") {
+            authenticateAs("ADMIN")
             val responseEntity = fileService.downloadFile(1L)
 
             Then("파일 리소스가 반환된다") {
@@ -218,6 +230,49 @@ class FileServiceTest : BehaviorSpec({
                 responseEntity.headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)!! shouldContain "download.txt"
                 verify(exactly = 1) { fileStorage.loadAsResource(fileEntity.filePath) }
                 verify(exactly = 1) { fileRepository.findByIdOrNull(1L) }
+            }
+        }
+    }
+
+    Given("STAFF가 문서(비-PHOTO) 파일 다운로드를 요청하고") {
+        val project = createProject()
+        val user = createUser()
+        val fileEntity = createFileEntity(1L, project, user, category = FileCategory.QUOTATION)
+
+        every { fileRepository.findByIdOrNull(1L) } returns fileEntity
+
+        When("파일을 다운로드하면") {
+            authenticateAs("STAFF")
+
+            Then("PERMISSION_DENIED 예외가 발생하고 스토리지에 접근하지 않는다") {
+                val exception = shouldThrow<CustomException> {
+                    fileService.downloadFile(1L)
+                }
+                exception.errorCode shouldBe ErrorCode.PERMISSION_DENIED
+                verify(exactly = 0) { fileStorage.loadAsResource(any()) }
+            }
+        }
+    }
+
+    Given("STAFF가 현장 사진(PHOTO) 파일 다운로드를 요청하고") {
+        val project = createProject()
+        val user = createUser()
+        val fileEntity = createFileEntity(1L, project, user, originalFileName = "site.jpg", category = FileCategory.PHOTO)
+
+        every { fileRepository.findByIdOrNull(1L) } returns fileEntity
+
+        val resource = mockk<Resource>()
+        every { fileStorage.loadAsResource(fileEntity.filePath) } returns resource
+        every { resource.exists() } returns true
+        every { resource.isReadable } returns true
+
+        When("파일을 다운로드하면") {
+            authenticateAs("STAFF")
+            val responseEntity = fileService.downloadFile(1L)
+
+            Then("PHOTO는 권한 제한 없이 반환된다") {
+                responseEntity.statusCode shouldBe HttpStatus.OK
+                verify(exactly = 1) { fileStorage.loadAsResource(fileEntity.filePath) }
             }
         }
     }

--- a/backend/src/test/kotlin/org/core/scheduleflow/global/security/jwt/JwtProviderTest.kt
+++ b/backend/src/test/kotlin/org/core/scheduleflow/global/security/jwt/JwtProviderTest.kt
@@ -1,12 +1,10 @@
 package org.core.scheduleflow.global.security.jwt
 
 import org.core.scheduleflow.domain.user.constant.Role
-import org.core.scheduleflow.global.exception.CustomException
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class JwtProviderTest {
 
@@ -34,13 +32,16 @@ class JwtProviderTest {
     }
 
     @Test
-    @DisplayName("위조된 토큰은 조회 실패")
+    @DisplayName("위조된 토큰은 검증 실패(Result.failure)를 반환한다")
     fun validateToken_invalidToken_fail() {
         // given
         val invalidToken = "this.is.invalid.token"
 
-        //when & then
-        assertThrows<CustomException> { jwtProvider.validateToken(invalidToken) }
+        // when
+        val result = jwtProvider.validateToken(invalidToken)
+
+        // then: 예외를 던지지 않고 실패 Result를 돌려준다(필터가 삼키고 401로 이어짐)
+        assertTrue(result.isFailure)
     }
 
 }


### PR DESCRIPTION
AWS 공개 배포를 앞두고 코드 리뷰(#103)에서 발견한 **배포 전 필수 보안 블로커 3건**을 조치하고, 함께 발견된 JWT 인증 실패 응답 버그를 수정했습니다.

관련 이슈: #103 (블로커 3건 조치. High/Medium 항목은 후속으로 잔존 — Close 아님)

## 변경 사항

### 1. 공개 회원가입 차단 (블로커)
- `/auth/**` 전역 `permitAll`이라 `POST /auth/sign-up`이 무인증 공개 → 인터넷 누구나 계정 생성 후 STAFF 토큰 획득 가능했음
- `SecurityConfig`의 permitAll을 `/auth/sign-in`만으로 좁히고, `signUp`에 `@PreAuthorize("hasRole('ADMIN')")` 부여 (이중 방어). 내부 ~10명 고정 도구라 계정은 ADMIN이 발급

### 2. 파일 다운로드 IDOR 인가 추가 (블로커)
- `GET /files/download/{fileId}`에 인가 검증이 전무 → 저권한 사용자가 `fileId` 순회로 ADMIN 전용 문서(견적서·회로도·PLC 등)를 전량 다운로드 가능했음
- 업로드 권한 분기와 **대칭**으로 수정: 문서 카테고리는 ADMIN만, 현장 사진(PHOTO)만 인증 사용자 누구나 다운로드

### 3. `GET /users` PII 노출 차단 (블로커)
- 유일하게 `@PreAuthorize` 누락 → 전 직원 username·email·phone·role이 무인가 노출됐음
- ADMIN 전용으로 게이트 (소비처가 모두 ADMIN 흐름: 프로젝트/일정 생성, 사원 관리 화면)

### 4. 유효하지 않은 JWT를 401로 일관 처리 (버그 수정)
- 필터에서 `validateToken`이 예외를 던져 `@RestControllerAdvice`가 못 잡고 500성 응답 → 프론트 인터셉터의 로그인 리다이렉트(401 조건)가 안 걸리던 문제
- `Result.failure` 반환으로 바꿔, 인증 미설정 → `JwtAuthenticationEntryPoint`가 일관된 401 반환 → `/login` 리다이렉트. 모바일/데스크톱 동일 동작

## 검증
- 백엔드 전체 테스트 `BUILD SUCCESSFUL`
- `FileServiceTest`에 다운로드 인가 케이스 추가: ADMIN 문서 허용 / STAFF 문서 거부(`PERMISSION_DENIED`) / STAFF PHOTO 허용
- `JwtProviderTest` 위조 토큰 케이스를 `Result.failure` 기대로 갱신

## 범위 밖 (후속, #103에 잔존)
- 파일 목록 메타데이터 IDOR(`GET /files`, `GET /files/{projectId}`), Swagger 공개 차단, 로그인 brute-force 방어, 업로드 검증/크기 제한, 토큰 수명·refresh 등
