### PR TITLE
fix: Spring Boot 4.0 Flyway 자동설정 모듈 누락 (운영 기동 실패 핫픽스)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4")
 
     // DB Migration
+    // Spring Boot 4.0은 자동설정을 모듈로 분리 — flyway-core만으론 FlywayAutoConfiguration이
+    // 클래스패스에 없어 Flyway가 아예 실행되지 않는다. 통합 모듈을 반드시 함께 넣어야 한다.
+    implementation("org.springframework.boot:spring-boot-flyway")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-mysql")
 


### PR DESCRIPTION
## 문제
#113 배포 후 백엔드가 기동 실패 → 로그인 불가(운영 다운). 로그:
```
Schema-validation: missing column [created_by] in table [files]
```

## 원인
- Spring Boot 4.0은 자동설정을 모듈로 분리했다. `FlywayAutoConfiguration`이 `spring-boot-autoconfigure`에서 **별도 모듈 `spring-boot-flyway`로 이동**.
- #113은 `flyway-core`/`flyway-mysql`(Flyway 라이브러리 본체)만 추가하고 이 통합 모듈을 빠뜨림 → **Flyway가 한 번도 실행되지 않음**(`flyway_schema_history` 미생성).
- 결과: `created_by` 컬럼 미생성 → `ddl-auto: validate` 실패 → 기동 불가.
- 배포 워크플로 헬스체크가 프론트 루트(`/`)만 확인해 백엔드 다운을 못 잡고 초록불로 표시됨.

## 조치
- `org.springframework.boot:spring-boot-flyway` 의존성 추가 → Flyway 자동설정 복구(런타임 클래스패스 확인 완료, 4.0.0).
- **운영 즉시 복구는 별도로 처리함**: 누락된 `created_by` 컬럼 6개 테이블(users/projects/partners/partner_contacts/schedules/files)에 수동 `ALTER ... ADD COLUMN ... DEFAULT 'SYSTEM'` 적용 → 백엔드 재기동 → 로그인 200 확인. V1 마이그레이션은 조건부(idempotent)라 다음 배포에서 Flyway가 baseline 후 no-op으로 V1을 기록한다.

## 배포
머지 → 이미지 재빌드(push to main) → 수동 Deploy. 이후 Flyway가 정상 baseline/기록되는지 로그 확인 권장.

## 후속(권장)
- 배포 헬스체크에 백엔드 경로(예: `/api` actuator health) 추가 — 이번처럼 백엔드 다운을 놓치지 않도록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)