### PR TITLE
feat: CloudWatch 모니터링 구축 — 자원 감시·로그·알람·대시보드 (#114)

### DIFF
--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "mem_high" {
   datapoints_to_alarm = 3
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = 90
-  treat_missing_data  = "missing" # 데이터 끊김(배포/재시작)은 알람 아님 — 죽음 감지는 UptimeRobot 몫
+  treat_missing_data  = "missing" # 데이터 끊김(배포/재시작)은 알람 아님. 박스 통째 죽음은 내부 감시로 못 잡음(사용자 신고로 감지 — 10명 내부도구라 UptimeRobot 생략)
 
   alarm_actions = [aws_sns_topic.alarms.arn]
   ok_actions    = [aws_sns_topic.alarms.arn] # 복구됐을 때도 통지
@@ -156,4 +156,136 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage_low" {
 
   alarm_actions = [aws_sns_topic.alarms.arn]
   ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# ════════════════════════════════════════════════════════════════
+# [Layer 4] 대시보드 — 한 판에 EC2 + RDS + 최근 에러 로그
+#   콘솔 애드혹 조회 대신 "자주 같이 보는 지표"를 고정 배치. 상시무료 3개 중 1개(=$0).
+#   그래프 위 점선 = 알람 임계선(annotations). InstanceId/RDS식별자는 리소스 참조.
+#   레이아웃: 24열 그리드, 위젯당 높이 6. 1행 EC2 / 2행 RDS / 3행 로그.
+# ════════════════════════════════════════════════════════════════
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "scheduleflow"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      # ── 1행: EC2 ──
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 8
+        height = 6
+        properties = {
+          title   = "EC2 메모리 사용률 (%)"
+          region  = "ap-northeast-2"
+          stat    = "Average"
+          period  = 300
+          metrics = [["CWAgent", "mem_used_percent", "InstanceId", aws_instance.app.id]]
+          yAxis   = { left = { min = 0, max = 100 } }
+          annotations = {
+            horizontal = [{ label = "알람 90%", value = 90 }]
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 0
+        width  = 8
+        height = 6
+        properties = {
+          title  = "EC2 디스크 사용률 (%)"
+          region = "ap-northeast-2"
+          stat   = "Average"
+          period = 300
+          metrics = [[
+            "CWAgent", "disk_used_percent",
+            "InstanceId", aws_instance.app.id,
+            "path", "/", "device", "nvme0n1p1", "fstype", "xfs"
+          ]]
+          yAxis = { left = { min = 0, max = 100 } }
+          annotations = {
+            horizontal = [{ label = "알람 85%", value = 85 }]
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 0
+        width  = 8
+        height = 6
+        properties = {
+          title   = "EC2 CPU 사용률 (%)"
+          region  = "ap-northeast-2"
+          stat    = "Average"
+          period  = 300
+          metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.app.id]]
+          yAxis   = { left = { min = 0, max = 100 } }
+        }
+      },
+      # ── 2행: RDS ──
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 8
+        height = 6
+        properties = {
+          title   = "RDS 여유 스토리지 (bytes)"
+          region  = "ap-northeast-2"
+          stat    = "Average"
+          period  = 300
+          metrics = [["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", aws_db_instance.main.identifier]]
+          annotations = {
+            horizontal = [{ label = "알람 2GiB", value = 2147483648 }]
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 6
+        width  = 8
+        height = 6
+        properties = {
+          title   = "RDS CPU 사용률 (%)"
+          region  = "ap-northeast-2"
+          stat    = "Average"
+          period  = 300
+          metrics = [["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", aws_db_instance.main.identifier]]
+          yAxis   = { left = { min = 0, max = 100 } }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 6
+        width  = 8
+        height = 6
+        properties = {
+          title   = "RDS 연결 수"
+          region  = "ap-northeast-2"
+          stat    = "Average"
+          period  = 300
+          metrics = [["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", aws_db_instance.main.identifier]]
+        }
+      },
+      # ── 3행: 로그 ──
+      {
+        type   = "log"
+        x      = 0
+        y      = 12
+        width  = 24
+        height = 6
+        properties = {
+          title  = "최근 에러 로그 (/scheduleflow/docker)"
+          region = "ap-northeast-2"
+          view   = "table"
+          query  = "SOURCE '/scheduleflow/docker' | fields @timestamp, @message | filter @message like /ERROR/ | sort @timestamp desc | limit 50"
+        }
+      },
+    ]
+  })
 }

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,0 +1,41 @@
+# ════════════════════════════════════════════════════════════════
+# CloudWatch — 로그 아카이브 + 메트릭 알람
+#
+# 역할 분담: Sentry = 예외 이벤트(조립된 스택트레이스), CloudWatch = Sentry가
+# 못 보는 것(메모리/디스크/RDS, 앱이 죽어서 아무것도 못 보낼 때의 상황) + 로그 원문 아카이브.
+# 둘은 서로 모르는 독립 평행 파이프라인.
+#
+# 이 파일은 [Layer 1] — 인스턴스를 건드리지 않는 것들만:
+#   ① EC2 role에 CloudWatch Agent 권한 부여
+#   ② 로그를 담을 log group (retention 필수)
+# 에이전트 설치/config(Layer 2)와 SNS/알람(Layer 3)은 뒤에 붙인다.
+# ════════════════════════════════════════════════════════════════
+
+# ────────────────────────────────────────────────
+# ① CloudWatch Agent 권한 — EC2 role에 관리형 정책 attach
+#   PutMetricData(메모리/디스크 메트릭) + logs:PutLogEvents(로그 전송)
+#   + ssm:GetParameter(Layer 2에서 config를 SSM Parameter Store에서 받아올 때) 포함.
+#   에이전트도 그냥 API 클라이언트 — 크레덴셜은 인스턴스 프로파일(IMDS)에서 받음, 하드코딩 0.
+# ────────────────────────────────────────────────
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
+  role       = aws_iam_role.ec2.name   # iam.tf 의 EC2 role 재사용
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# ────────────────────────────────────────────────
+# ② Log group — 컨테이너 로그(json-file)를 에이전트가 tail해서 여기로 보냄
+#   컨테이너 json-file 경로가 컨테이너ID 기반이라 서비스별 분리가 불가 → 단일 그룹에 합침.
+#   멀티라인(자바 스택트레이스) 깨짐은 허용 — 조립된 스택트레이스는 Sentry가 가지고 있고,
+#   CloudWatch는 "아카이브 + OOM/죽음 감지"가 역할이라 원문 라인만 찾으면 충분.
+#
+#   retention 반드시 지정! 기본이 무기한이라 안 걸면 로그 저장비가 S3보다 나옴.
+#   10명 트래픽 + 아카이브 용도 → 14일이면 사고 조사에 충분.
+# ────────────────────────────────────────────────
+resource "aws_cloudwatch_log_group" "docker" {
+  name              = "/scheduleflow/docker"
+  retention_in_days = 14
+
+  tags = {
+    Name = "scheduleflow-docker-logs"
+  }
+}

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -60,3 +60,100 @@ resource "aws_ssm_parameter" "cwagent_config" {
     Name = "scheduleflow-cwagent-config"
   }
 }
+
+# ════════════════════════════════════════════════════════════════
+# [Layer 3] SNS + 알람
+#   알람은 "숫자가 임계값 넘었나"만 판단하고, 넘으면 액션으로 SNS ARN을 호출한다.
+#   SNS는 CloudWatch가 아닌 별개 서비스 — 알람은 SNS든 Lambda든 상관 안 하고 ARN만 부름.
+# ════════════════════════════════════════════════════════════════
+
+# ── 알림 채널: SNS 토픽 + 이메일 구독 ──────────────
+#   이메일 구독은 생성 직후 "PendingConfirmation" 상태 — AWS가 보낸 확인 메일의
+#   링크를 클릭해야 실제로 알림이 온다. (apply만으론 활성화 안 됨)
+resource "aws_sns_topic" "alarms" {
+  name = "scheduleflow-alarms"
+}
+
+resource "aws_sns_topic_subscription" "alarms_email" {
+  topic_arn = aws_sns_topic.alarms.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+# ── 알람 ①: 메모리 ────────────────────────────────
+#   정상 상태가 이미 ~80%(t4g.micro 1GB에 JVM 등 4프로세스)라, 85% 단발이면
+#   GC 스파이크마다 울린다. 진짜 위험은 "지속적으로 90% 넘어 OOM으로 가는" 상황 →
+#   5분 평균 × 3회 연속(=15분 지속)일 때만 발화하게 해서 잔진동을 걸러낸다.
+resource "aws_cloudwatch_metric_alarm" "mem_high" {
+  alarm_name        = "scheduleflow-mem-high"
+  alarm_description = "메모리 사용률이 15분 이상 지속적으로 90%를 초과 (OOM 위험)"
+
+  namespace   = "CWAgent"
+  metric_name = "mem_used_percent"
+  dimensions = {
+    InstanceId = aws_instance.app.id
+  }
+
+  statistic           = "Average"
+  period              = 300   # 5분
+  evaluation_periods  = 3     # 3회 연속
+  datapoints_to_alarm = 3
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 90
+  treat_missing_data  = "missing" # 데이터 끊김(배포/재시작)은 알람 아님 — 죽음 감지는 UptimeRobot 몫
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn] # 복구됐을 때도 통지
+}
+
+# ── 알람 ②: 디스크(루트 볼륨) ─────────────────────
+#   디스크는 로그/이미지 누적으로 천천히 차므로 지속 조건은 약하게(5분 × 2회).
+#   85%면 여유 있을 때 손 쓰라는 신호. (uploads는 prod에서 S3라 로컬 디스크 부담 아님)
+resource "aws_cloudwatch_metric_alarm" "disk_high" {
+  alarm_name        = "scheduleflow-disk-high"
+  alarm_description = "루트 볼륨 사용률이 85%를 초과 (로그/이미지 누적)"
+
+  namespace   = "CWAgent"
+  metric_name = "disk_used_percent"
+  dimensions = {
+    InstanceId = aws_instance.app.id
+    path       = "/"
+    device     = "nvme0n1p1" # 루트 파티션 (AL2023 arm64 nvme)
+    fstype     = "xfs"
+  }
+
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 85
+  treat_missing_data  = "missing"
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}
+
+# ── 알람 ③: RDS 여유 스토리지 ─────────────────────
+#   EC2 디스크만큼 조용한 살인마인데 Sentry 사각. managed라 공짜 메트릭.
+#   할당 20GB 중 2GB 미만(=90% 사용) 남으면 발화. FreeStorageSpace는 "바이트" 단위.
+resource "aws_cloudwatch_metric_alarm" "rds_storage_low" {
+  alarm_name        = "scheduleflow-rds-storage-low"
+  alarm_description = "RDS 여유 스토리지가 2GB 미만 (스토리지 고갈 임박)"
+
+  namespace   = "AWS/RDS"
+  metric_name = "FreeStorageSpace"
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.identifier
+  }
+
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 1
+  comparison_operator = "LessThanThreshold"
+  threshold           = 2147483648 # 2 GiB (2 * 1024^3 바이트)
+  treat_missing_data  = "missing"
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+}

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -39,3 +39,24 @@ resource "aws_cloudwatch_log_group" "docker" {
     Name = "scheduleflow-docker-logs"
   }
 }
+
+# ────────────────────────────────────────────────
+# [Layer 2] 에이전트 config — SSM Parameter Store에 저장
+#   에이전트가 부팅/설치 시 `-c ssm:<이름>`으로 이 값을 받아 기동한다.
+#   config 실물은 cwagent-config.json (file()로 원문 주입 — templatefile이 아니라
+#   ${aws:InstanceId} 같은 런타임 치환자를 Terraform이 안 건드리고 그대로 넘김).
+#
+#   ⚠ 이름을 반드시 "AmazonCloudWatch-"로 시작할 것.
+#   Layer 1에서 붙인 CloudWatchAgentServerPolicy는 ssm:GetParameter를
+#   Resource=parameter/AmazonCloudWatch-* 로만 허용한다. 다른 이름이면 에이전트가
+#   config를 못 읽어 별도 IAM이 필요 → AWS가 정한 이 접두사를 그대로 따른다.
+# ────────────────────────────────────────────────
+resource "aws_ssm_parameter" "cwagent_config" {
+  name  = "AmazonCloudWatch-scheduleflow-agent-config"
+  type  = "String"
+  value = file("${path.module}/cwagent-config.json")
+
+  tags = {
+    Name = "scheduleflow-cwagent-config"
+  }
+}

--- a/infra/cwagent-config.json
+++ b/infra/cwagent-config.json
@@ -1,0 +1,34 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root"
+  },
+  "metrics": {
+    "namespace": "CWAgent",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "mem": {
+        "measurement": ["mem_used_percent"]
+      },
+      "disk": {
+        "measurement": ["disk_used_percent"],
+        "resources": ["/"]
+      }
+    }
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/lib/docker/containers/*/*-json.log",
+            "log_group_name": "/scheduleflow/docker",
+            "log_stream_name": "{instance_id}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,21 +1,14 @@
 # ────────────────────────────────────────────────
-# ② AMI 자동 선택 — 최신 Amazon Linux 2023 (ARM64)
-#   data 소스로 "최신 이미지"를 매번 찾아옴 → ID 하드코딩 안 함.
-#   t4g/t3 계열에 맞춰 arm64 선택 (t4g=ARM, 저렴).
+# ② AMI — 최초 생성 시점의 Amazon Linux 2023 (ARM64)에 고정
+#   과거엔 data.aws_ami(most_recent=true)로 "최신"을 매번 찾았는데, 그러면
+#   Amazon이 새 AMI를 낼 때마다 id가 바뀌어 apply 시 인스턴스 강제 재생성이 발동함
+#   (AMI는 생성 후 못 바꾸는 속성 → in-place 불가 → destroy+create = 실사용자 다운타임).
+#   그래서 지금 돌고 있는 AMI id로 명시 고정한다. 보안 업데이트는 박스 안 dnf로 처리.
+#   새 AMI로 갈아탈 땐 아래 id를 의도적으로 바꿔서 계획된 재생성으로 진행.
+#   (최신 AL2023 arm64 조회: aws ec2 describe-images --owners amazon
+#     --filters "Name=name,Values=al2023-ami-*-arm64" --query
+#     'sort_by(Images,&CreationDate)[-1].ImageId' --output text)
 # ────────────────────────────────────────────────
-data "aws_ami" "al2023" {
-  most_recent = true
-  owners      = ["amazon"]   # Amazon 공식 이미지만
-
-  filter {
-    name   = "name"
-    values = ["al2023-ami-*-arm64"]   # Amazon Linux 2023, ARM64
-  }
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
 
 # ────────────────────────────────────────────────
 # ③ user-data — 부팅 시 1회 실행되는 초기화 스크립트
@@ -48,7 +41,7 @@ locals {
 # ④ EC2 인스턴스 — 위 ①②③을 조립
 # ────────────────────────────────────────────────
 resource "aws_instance" "app" {
-  ami           = data.aws_ami.al2023.id       # ②에서 찾은 최신 이미지
+  ami           = "ami-03c1733c4f6df5149"      # ②에서 고정한 AL2023 arm64 (최초 생성분)
   instance_type = "t4g.micro"                  # ARM
 
   subnet_id                   = aws_subnet.public_a.id          # public subnet

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -15,6 +15,12 @@
 #   docker/compose 설치까지만. (앱 배포는 나중에 CI/CD 또는 수동)
 #   heredoc(<<-EOF)으로 여러 줄 셸 스크립트를 그대로 넣음.
 # ────────────────────────────────────────────────
+# NOTE(#114): CloudWatch 에이전트는 이 user_data에 없음 — 라이브 인스턴스에
+#   SSM Run Command로 무중단 설치했다(dnf install amazon-cloudwatch-agent +
+#   fetch-config -c ssm:AmazonCloudWatch-scheduleflow-agent-config).
+#   재생성된 새 박스엔 자동 설치가 안 되니, 재현성이 필요하면 그 두 줄을 아래 heredoc에
+#   추가하거나 배포 스크립트로 옮길 것. (heredoc 안을 바꾸면 user_data가 변해 라이브
+#   인스턴스 in-place 업데이트가 걸리니, 이 메모는 heredoc 밖에 둔다.)
 locals {
   user_data = <<-EOF
     #!/bin/bash

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -24,3 +24,8 @@ variable "s3_bucket" {
   type        = string
   default     = "scheduleflow-files-606531136262"
 }
+
+variable "alarm_email" {
+  description = "CloudWatch 알람을 받을 이메일 (SNS 구독 → 확인 메일 클릭 필요). terraform.tfvars에 넣기."
+  type        = string
+}


### PR DESCRIPTION
EC2 1대 + docker-compose 운영 환경에 CloudWatch 파이프라인을 붙인다. 자원 감시(메모리/디스크/RDS) + 로그 아카이브 + 이메일 알람 + 대시보드를 무중단으로 라이브 반영했다. Sentry가 못 보는 영역(자원 고갈, 앱이 죽어 아무것도 못 보낼 때)을 메우는 독립 파이프라인.

## 관련 이슈
- Related to #114 — 모니터링 구축 (우산 이슈, 이 PR은 CloudWatch 부분)

## 변경 사항
### 1. EC2 AMI 명시 고정 (fix)
- `data.aws_ami(most_recent=true)`는 Amazon이 새 AMI를 낼 때마다 apply 시 인스턴스 강제 재생성(다운타임)을 유발하던 잠복 지뢰 → 현재 AMI ID로 명시 고정
- CloudWatch와 무관하나 작업 중 발견해 함께 제거

### 2. Layer 1 — IAM + 로그그룹
- EC2 role에 `CloudWatchAgentServerPolicy` attach
- 로그그룹 `/scheduleflow/docker`, retention 14일

### 3. Layer 2 — 에이전트 config (SSM)
- `cwagent-config.json`: mem/disk 메트릭 + docker json-file 로그 tail (`run_as_user=root` — 로그가 root:root 0600)
- SSM 파라미터명 `AmazonCloudWatch-` 접두사 → 관리형 정책의 `ssm:GetParameter` 범위에 맞춰 별도 IAM 회피
- 라이브 인스턴스엔 SSM Run Command로 무중단 설치 (user_data 미포함, 사유는 코드 주석)

### 4. Layer 3 — SNS 알람 3종
- 메모리 ≥90% (5분×3회 지속 — 정상이 ~80%라 85% 단발은 GC 스파이크마다 울림)
- 디스크 ≥85% (5분×2회)
- RDS FreeStorageSpace <2GiB
- 셋 다 `ok_actions`로 복구 통지까지

### 5. Layer 4 — 대시보드
- EC2(메모리·디스크·CPU) + RDS(스토리지·CPU·연결수) + 최근 에러 로그 한 판, 알람 임계선 표시

## 검증
- `terraform apply` 각 레이어별 클린 반영 (인스턴스 무중단)
- 메트릭·로그 수신 확인 (get-metric-statistics로 데이터포인트, 로그그룹 스트림)
- 알람→SNS→이메일 경로 `set-alarm-state` 강제 발화로 검증, 3개 모두 OK 안착
- 대시보드 콘솔 렌더 확인

## 비용
- 사실상 $0 — 알람 3개·커스텀 메트릭 2개는 상시무료(각 10개) 범위, 로그 수집은 무료 5GB 내(10명 트래픽), SNS 이메일 월 1,000통 무료, 대시보드 3개 무료 중 1개

## 범위 밖 (후속)
- Sentry Tier2 e2e 검증 (5xx 유발해 대시보드 확인) — #114 잔여
- UptimeRobot(외부 죽음 감지) — 10명 내부 도구라 사용자 신고가 외부 감시 역할, 의도적 생략
- 에이전트 설치 user_data 재현성 — AMI 고정으로 자동 재생성 없어 후순위
